### PR TITLE
Typo fixes in the guide

### DIFF
--- a/docs/src/Setup/pcie_setup.rst
+++ b/docs/src/Setup/pcie_setup.rst
@@ -34,4 +34,4 @@ Here's how to clone/build/load this driver:
    $ sudo chmod 666 /dev/datadev*
 
    # Check for the loaded device
-   $ cat /proc/datadev0
+   $ cat /proc/datadev_0

--- a/docs/src/Setup/rogue_setup.rst
+++ b/docs/src/Setup/rogue_setup.rst
@@ -7,6 +7,8 @@ Rogue Software Setup
 If you are on the SLAC AFS network
 ==================================
 
+After you have cloned the repository :ref:`how_to_git_clone`
+
 Here's how to setup the SLAC AFS conda build of rogue:
 
 .. code-block:: bash

--- a/docs/src/Setup/vivado_setup.rst
+++ b/docs/src/Setup/vivado_setup.rst
@@ -7,7 +7,9 @@ Vivado and VCS Setup
 If you are on the SLAC AFS network
 ==================================
 
-Here's how to setup the Xilinx tools and licensing
+After you have cloned the repository :ref:`how_to_git_clone`
+
+Here's how to setup the Xilinx tools and licensing:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Hello Larry,

1)I fixed what I think is a typo in the pcie_setup.rst: for me the driver was loaded with the underscore, I do not know if it depends on the system version or others.

2)  If someone follows the guide step by step, in rogue_setup.rst and vivado_setup.rst is given some scripts to run, but still has not downloaded the repo. I added the link to that page in both istances.